### PR TITLE
More (and fewer) conversions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,32 @@
 var conversions = {};
 module.exports = conversions;
 
+function Type(V) {
+    if (V === null) {
+        return "Null";
+    }
+    switch (typeof V) {
+        case "undefined":
+            return "Undefined";
+        case "boolean":
+            return "Boolean";
+        case "number":
+            return "Number";
+        case "string":
+            return "String";
+        case "symbol":
+            return "Symbol";
+        case "object":
+        case "function":
+        // Per ES spec, typeof returns an implemention-defined value that is
+        // not any of the existing ones for uncallable non-standard exotic
+        // objects. Yet Type() which the Web IDL spec depends on returns
+        // Object for such cases. So treat the default case as an object.
+        default:
+            return "Object";
+    }
+}
+
 function sign(x) {
     return x < 0 ? -1 : 1;
 }
@@ -72,6 +98,26 @@ function createNumberConversion(bitLength, typeOpts) {
         return x;
     }
 }
+
+conversions["any"] = function (V) {
+    if (V === undefined || V === null) {
+        return V;
+    }
+    switch (Type(V)) {
+        case "Boolean":
+            return !!V;
+        case "Number":
+            return conversions["unrestricted double"](V);
+        case "String":
+            return conversions["DOMString"](V);
+        case "Object":
+            return V;
+        // Not yet defined by Web IDL spec
+        // See https://github.com/heycam/webidl/issues/301
+        case "Symbol":
+            return V;
+    }
+};
 
 conversions["void"] = function () {
     return undefined;
@@ -199,6 +245,25 @@ conversions["USVString"] = function (V) {
     return U.join('');
 };
 
+conversions["object"] = function (V, opts) {
+    if (Type(V) !== "Object") {
+        throw new TypeError("Argument is not an object");
+    }
+
+    return V;
+};
+
+// Not exported, but used in Function and VoidFunction.
+
+// Neither Function nor VoidFunction is defined with [TreatNonObjectAsNull], so
+// handling for that is omitted.
+function convertCallbackFunction(V, opts) {
+    if (typeof V !== "function") {
+        throw new TypeError("Argument is not a function");
+    }
+    return V;
+};
+
 conversions["Date"] = function (V, opts) {
     if (!(V instanceof Date)) {
         throw new TypeError("Argument is not a Date object");
@@ -217,3 +282,67 @@ conversions["RegExp"] = function (V, opts) {
 
     return V;
 };
+
+conversions["Error"] = function (V, opts) {
+    if (!(V instanceof Error)) {
+        throw new TypeError("Argument is not an Error object");
+    }
+
+    return V;
+};
+
+conversions["ArrayBuffer"] = function (V, opts) {
+    // Unfortunately, the IsDetachedBuffer abstract operation is not exposed
+    // through JS.
+    if (!(V instanceof ArrayBuffer)) {
+        throw new TypeError("Argument is not an ArrayBuffer object");
+    }
+
+    return V;
+};
+
+conversions["DataView"] = function (V, opts) {
+    if (!(V instanceof DataView)) {
+        throw new TypeError("Argument is not a DataView object");
+    }
+
+    return V;
+};
+
+[
+    Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array,
+    Uint8ClampedArray, Float32Array, Float64Array
+].forEach(function (func) {
+    const name = func.name;
+    conversions[name] = function (V, opts) {
+        if (!(V instanceof func)) {
+            throw new TypeError("Argument is not a " + name + " object");
+        }
+
+        return V;
+    };
+});
+
+// Common definitions
+
+conversions["ArrayBufferView"] = function (V, opts) {
+    if (!ArrayBuffer.isView(V)) {
+        throw new TypeError("Argument is not a view on an ArrayBuffer object");
+    }
+
+    return V;
+};
+
+conversions["BufferSource"] = function (V, opts) {
+    if (!(ArrayBuffer.isView(V) || V instanceof ArrayBuffer)) {
+        throw new TypeError("Argument is not an ArrayBuffer object or a view on one");
+    }
+
+    return V;
+};
+
+conversions["DOMTimeStamp"] = conversions["unsigned long long"];
+
+conversions["Function"] = convertCallbackFunction;
+
+conversions["VoidFunction"] = convertCallbackFunction;

--- a/lib/index.js
+++ b/lib/index.js
@@ -264,25 +264,6 @@ function convertCallbackFunction(V, opts) {
     return V;
 };
 
-conversions["Date"] = function (V, opts) {
-    if (!(V instanceof Date)) {
-        throw new TypeError("Argument is not a Date object");
-    }
-    if (isNaN(V)) {
-        return undefined;
-    }
-
-    return V;
-};
-
-conversions["RegExp"] = function (V, opts) {
-    if (!(V instanceof RegExp)) {
-        V = new RegExp(V);
-    }
-
-    return V;
-};
-
 conversions["Error"] = function (V, opts) {
     if (!(V instanceof Error)) {
         throw new TypeError("Argument is not an Error object");

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,10 +106,6 @@ conversions["double"] = function (V) {
 conversions["unrestricted double"] = function (V) {
     const x = +V;
 
-    if (isNaN(x)) {
-        throw new TypeError("Argument is NaN");
-    }
-
     return x;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,23 +100,7 @@ function createNumberConversion(bitLength, typeOpts) {
 }
 
 conversions["any"] = function (V) {
-    if (V === undefined || V === null) {
-        return V;
-    }
-    switch (Type(V)) {
-        case "Boolean":
-            return !!V;
-        case "Number":
-            return conversions["unrestricted double"](V);
-        case "String":
-            return conversions["DOMString"](V);
-        case "Object":
-            return V;
-        // Not yet defined by Web IDL spec
-        // See https://github.com/heycam/webidl/issues/301
-        case "Symbol":
-            return V;
-    }
+    return V;
 };
 
 conversions["void"] = function () {
@@ -245,7 +229,7 @@ conversions["USVString"] = function (V) {
     return U.join('');
 };
 
-conversions["object"] = function (V, opts) {
+conversions["object"] = function (V) {
     if (Type(V) !== "Object") {
         throw new TypeError("Argument is not an object");
     }
@@ -257,47 +241,24 @@ conversions["object"] = function (V, opts) {
 
 // Neither Function nor VoidFunction is defined with [TreatNonObjectAsNull], so
 // handling for that is omitted.
-function convertCallbackFunction(V, opts) {
+function convertCallbackFunction(V) {
     if (typeof V !== "function") {
         throw new TypeError("Argument is not a function");
     }
     return V;
 };
 
-conversions["Error"] = function (V, opts) {
-    if (!(V instanceof Error)) {
-        throw new TypeError("Argument is not an Error object");
-    }
-
-    return V;
-};
-
-conversions["ArrayBuffer"] = function (V, opts) {
-    // Unfortunately, the IsDetachedBuffer abstract operation is not exposed
-    // through JS.
-    if (!(V instanceof ArrayBuffer)) {
-        throw new TypeError("Argument is not an ArrayBuffer object");
-    }
-
-    return V;
-};
-
-conversions["DataView"] = function (V, opts) {
-    if (!(V instanceof DataView)) {
-        throw new TypeError("Argument is not a DataView object");
-    }
-
-    return V;
-};
-
 [
-    Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array,
-    Uint8ClampedArray, Float32Array, Float64Array
+    Error,
+    ArrayBuffer, // The IsDetachedBuffer abstract operation is not exposed in JS
+    DataView, Int8Array, Int16Array, Int32Array, Uint8Array,
+    Uint16Array, Uint32Array, Uint8ClampedArray, Float32Array, Float64Array
 ].forEach(function (func) {
     const name = func.name;
-    conversions[name] = function (V, opts) {
+    const article = /^[AEIOU]/.test(name) ? "an" : "a";
+    conversions[name] = function (V) {
         if (!(V instanceof func)) {
-            throw new TypeError("Argument is not a " + name + " object");
+            throw new TypeError(`Argument is not ${article} ${name} object`);
         }
 
         return V;
@@ -306,7 +267,7 @@ conversions["DataView"] = function (V, opts) {
 
 // Common definitions
 
-conversions["ArrayBufferView"] = function (V, opts) {
+conversions["ArrayBufferView"] = function (V) {
     if (!ArrayBuffer.isView(V)) {
         throw new TypeError("Argument is not a view on an ArrayBuffer object");
     }
@@ -314,7 +275,7 @@ conversions["ArrayBufferView"] = function (V, opts) {
     return V;
 };
 
-conversions["BufferSource"] = function (V, opts) {
+conversions["BufferSource"] = function (V) {
     if (!(ArrayBuffer.isView(V) || V instanceof ArrayBuffer)) {
         throw new TypeError("Argument is not an ArrayBuffer object or a view on one");
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,9 +109,43 @@ conversions["unrestricted double"] = function (V) {
     return x;
 };
 
-// not quite valid, but good enough for JS
-conversions["float"] = conversions["double"];
-conversions["unrestricted float"] = conversions["unrestricted double"];
+conversions["float"] = function (V) {
+    const x = +V;
+
+    if (!Number.isFinite(x)) {
+        throw new TypeError("Argument is not a finite floating-point value");
+    }
+
+    if (Object.is(x, -0)) {
+        return x;
+    }
+
+    const array = new Float32Array(1);
+    array[0] = x;
+    const y = array[0];
+
+    if (!Number.isFinite(y)) {
+        throw new TypeError("Argument is not within the range of a single-precision floating-point value");
+    }
+
+    return y;
+};
+
+conversions["unrestricted float"] = function (V) {
+    const x = +V;
+
+    if (isNaN(x)) {
+        return x;
+    }
+
+    if (Object.is(x, -0)) {
+        return x;
+    }
+
+    const array = new Float32Array(1);
+    array[0] = x;
+    return array[0];
+};
 
 conversions["DOMString"] = function (V, opts) {
     if (!opts) opts = {};

--- a/test/any.js
+++ b/test/any.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+describe("WebIDL any type", () => {
+    const sut = conversions["any"];
+
+    it("should return `undefined` for `undefined`", () => {
+        assert.strictEqual(sut(undefined), undefined);
+    });
+
+    it("should return `null` for `null`", () => {
+        assert.strictEqual(sut(null), null);
+    });
+
+    it("should return `true` for `true`", () => {
+        assert.strictEqual(sut(true), true);
+    });
+
+    it("should return `false` for `false`", () => {
+        assert.strictEqual(sut(false), false);
+    });
+
+    it("should return `Infinity` for `Infinity`", () => {
+        assert.strictEqual(sut(Infinity), Infinity);
+    });
+
+    it("should return `-Infinity` for `-Infinity`", () => {
+        assert.strictEqual(sut(-Infinity), -Infinity);
+    });
+
+    it("should return `NaN` for `NaN`", () => {
+        assert(isNaN(sut(NaN)));
+    });
+
+    it("should return `0` for `0`", () => {
+        assert.strictEqual(sut(0), 0);
+    });
+
+    it("should return `-0` for `-0`", () => {
+        assert(Object.is(sut(-0), -0));
+    });
+
+    it("should return `1` for `1`", () => {
+        assert.strictEqual(sut(1), 1);
+    });
+
+    it("should return `-1` for `-1`", () => {
+        assert.strictEqual(sut(-1), -1);
+    });
+
+    it("should return `''` for `''`", () => {
+        assert.strictEqual(sut(""), "");
+    });
+
+    it("should return `'a'` for `'a'`", () => {
+        assert.strictEqual(sut("a"), "a");
+    });
+
+    it("should return `{}` for `{}`", () => {
+        const obj = {};
+        assert.strictEqual(sut(obj), obj);
+    });
+
+    it("should return `() => {}` for `() => {}`", () => {
+        const func = () => {};
+        assert.strictEqual(sut(func), func);
+    });
+});

--- a/test/buffer-source.js
+++ b/test/buffer-source.js
@@ -63,8 +63,8 @@ function testNotOk(name, sut, create) {
     });
 }
 
-const objCreators = [
-    [ DataView, () => new DataView(new ArrayBuffer(0)) ]
+const bufferSourceCreators = [
+    { constructor: DataView, creator: () => new DataView(new ArrayBuffer(0)) }
 ];
 
 [
@@ -78,18 +78,18 @@ const objCreators = [
     Uint8ClampedArray,
     Float32Array,
     Float64Array
-].forEach((ctor) => {
-    objCreators.push([ctor, () => new ctor(0)]);
+].forEach((constructor) => {
+    bufferSourceCreators.push({ constructor, creator: () => new constructor(0) });
 });
 
-objCreators.forEach((type) => {
-    const name = type[0].name;
+bufferSourceCreators.forEach((type) => {
+    const name = type.constructor.name;
     const sut = conversions[name];
 
     describe("WebIDL " + name + " type", () => {
-        objCreators.forEach((innerType) => {
-            const name = innerType[0].name;
-            const create = innerType[1];
+        bufferSourceCreators.forEach((innerType) => {
+            const name = innerType.constructor.name;
+            const create = innerType.creator;
 
             (innerType === type ? testOk : testNotOk)(name, sut, create);
         });
@@ -101,9 +101,9 @@ objCreators.forEach((type) => {
 describe("WebIDL ArrayBufferView type", () => {
     const sut = conversions["ArrayBufferView"];
 
-    objCreators.forEach((type) => {
-        const name = type[0].name;
-        const create = type[1];
+    bufferSourceCreators.forEach((type) => {
+        const name = type.constructor.name;
+        const create = type.creator;
 
         (name === "ArrayBuffer" ? testNotOk : testOk)(name, sut, create);
     });
@@ -114,9 +114,9 @@ describe("WebIDL ArrayBufferView type", () => {
 describe("WebIDL BufferSource type", () => {
     const sut = conversions["BufferSource"];
 
-    objCreators.forEach((type) => {
-        const name = type[0].name;
-        const create = type[1];
+    bufferSourceCreators.forEach((type) => {
+        const name = type.constructor.name;
+        const create = type.creator;
 
         testOk(name, sut, create);
     });

--- a/test/buffer-source.js
+++ b/test/buffer-source.js
@@ -1,0 +1,125 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+function commonNotOk(sut) {
+    it("should throw a TypeError for `undefined`", () => {
+        assert.throws(() => sut(undefined), TypeError);
+    });
+
+    it("should throw a TypeError for `null`", () => {
+        assert.throws(() => sut(null), TypeError);
+    });
+
+    it("should throw a TypeError for `true`", () => {
+        assert.throws(() => sut(true), TypeError);
+    });
+
+    it("should throw a TypeError for `false`", () => {
+        assert.throws(() => sut(false), TypeError);
+    });
+
+    it("should throw a TypeError for `Infinity`", () => {
+        assert.throws(() => sut(Infinity), TypeError);
+    });
+
+    it("should throw a TypeError for `NaN`", () => {
+        assert.throws(() => sut(NaN), TypeError);
+    });
+
+    it("should throw a TypeError for `0`", () => {
+        assert.throws(() => sut(0), TypeError);
+    });
+
+    it("should throw a TypeError for `''`", () => {
+        assert.throws(() => sut(""), TypeError);
+    });
+
+    it("should throw a TypeError for `Symbol.iterator`", () => {
+        assert.throws(() => sut(Symbol.iterator), TypeError);
+    });
+
+    it("should throw a TypeError for `{}`", () => {
+        assert.throws(() => sut({}), TypeError);
+    });
+
+    it("should throw a TypeError for `() => {}`", () => {
+        assert.throws(() => sut(() => {}), TypeError);
+    });
+}
+
+function testOk(name, sut, create) {
+    it("should return `" + name + "` object for `" + name + "` object", () => {
+        const obj = create();
+        assert.strictEqual(sut(obj), obj);
+    });
+}
+
+function testNotOk(name, sut, create) {
+    it("should throw a TypeError for `" + name + "` object", () => {
+        assert.throws(() => sut(create()), TypeError);
+    });
+}
+
+const objCreators = [
+    [ DataView, () => new DataView(new ArrayBuffer(0)) ]
+];
+
+[
+    ArrayBuffer,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8ClampedArray,
+    Float32Array,
+    Float64Array
+].forEach((ctor) => {
+    objCreators.push([ctor, () => new ctor(0)]);
+});
+
+objCreators.forEach((type) => {
+    const name = type[0].name;
+    const sut = conversions[name];
+
+    describe("WebIDL " + name + " type", () => {
+        objCreators.forEach((innerType) => {
+            const name = innerType[0].name;
+            const create = innerType[1];
+
+            (innerType === type ? testOk : testNotOk)(name, sut, create);
+        });
+
+        commonNotOk(sut);
+    });
+});
+
+describe("WebIDL ArrayBufferView type", () => {
+    const sut = conversions["ArrayBufferView"];
+
+    objCreators.forEach((type) => {
+        const name = type[0].name;
+        const create = type[1];
+
+        (name === "ArrayBuffer" ? testNotOk : testOk)(name, sut, create);
+    });
+
+    commonNotOk(sut);
+});
+
+describe("WebIDL BufferSource type", () => {
+    const sut = conversions["BufferSource"];
+
+    objCreators.forEach((type) => {
+        const name = type[0].name;
+        const create = type[1];
+
+        testOk(name, sut, create);
+    });
+
+    commonNotOk(sut);
+});

--- a/test/dom-time-stamp.js
+++ b/test/dom-time-stamp.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+describe("WebIDL DOMTimeStamp type", () => {
+    const sut = conversions["DOMTimeStamp"];
+
+    it("should have the same conversion routine as unsigned long long type", () => {
+        assert.strictEqual(sut, conversions["unsigned long long"]);
+    });
+});

--- a/test/double.js
+++ b/test/double.js
@@ -5,9 +5,7 @@ const conversions = require("..");
 // Adapted pretty directly from
 // https://github.com/marcoscaceres/webidl.js/blob/e631bcf2c1ba2d3ea283f5a39ed7bd1470743552/test/WebIDL.Double-tests.js
 
-describe("WebIDL double type", () => {
-    var sut = conversions["double"];
-
+function commonTest(sut) {
     it("should return `0` for `0`", () => {
         assert.strictEqual(sut(0), 0);
     });
@@ -43,6 +41,12 @@ describe("WebIDL double type", () => {
     it("should return `-123.123` for `\" -123.123 \"`", () => {
         assert.strictEqual(sut(" -123.123 "), -123.123);
     });
+}
+
+describe("WebIDL double type", () => {
+    var sut = conversions["double"];
+
+    commonTest(sut);
 
     it("should throw a TypeError for no argument", () => {
         assert.throws(() => sut(), TypeError);
@@ -66,5 +70,35 @@ describe("WebIDL double type", () => {
 
     it("should throw a TypeError for `\" 123,123 \"` (since it becomes `NaN`)", () => {
         assert.throws(() => sut(" 123,123 "), TypeError);
+    });
+});
+
+describe("WebIDL unrestricted double type", () => {
+    var sut = conversions["unrestricted double"];
+
+    commonTest(sut);
+
+    it("should return `NaN` for no argument", () => {
+        assert(isNaN(sut()));
+    });
+
+    it("should return `NaN for `undefined`", () => {
+        assert(isNaN(sut(undefined)));
+    });
+
+    it("should return `NaN for `NaN`", () => {
+        assert(isNaN(sut(NaN)));
+    });
+
+    it("should return `+Infinity` for `+Infinity`", () => {
+        assert.strictEqual(sut(+Infinity), +Infinity);
+    });
+
+    it("should return `-Infinity` for `-Infinity`", () => {
+        assert.strictEqual(sut(-Infinity), -Infinity);
+    });
+
+    it("should return `NaN for `\" 123,123 \"` (since it becomes `NaN`)", () => {
+        assert(isNaN(sut(" 123,123 ")));
     });
 });

--- a/test/double.js
+++ b/test/double.js
@@ -38,16 +38,12 @@ function commonTest(sut) {
         assert.strictEqual(sut(" 123 "), 123);
     });
 
-    it("should return `-123.123` for `\" -123.123 \"`", () => {
-        assert.strictEqual(sut(" -123.123 "), -123.123);
+    it("should return `-123.5` for `\" -123.500 \"`", () => {
+        assert.strictEqual(sut(" -123.500 "), -123.5);
     });
 }
 
-describe("WebIDL double type", () => {
-    var sut = conversions["double"];
-
-    commonTest(sut);
-
+function commonRestricted(sut) {
     it("should throw a TypeError for no argument", () => {
         assert.throws(() => sut(), TypeError);
     });
@@ -71,13 +67,9 @@ describe("WebIDL double type", () => {
     it("should throw a TypeError for `\" 123,123 \"` (since it becomes `NaN`)", () => {
         assert.throws(() => sut(" 123,123 "), TypeError);
     });
-});
+}
 
-describe("WebIDL unrestricted double type", () => {
-    var sut = conversions["unrestricted double"];
-
-    commonTest(sut);
-
+function commonUnrestricted(sut) {
     it("should return `NaN` for no argument", () => {
         assert(isNaN(sut()));
     });
@@ -100,5 +92,73 @@ describe("WebIDL unrestricted double type", () => {
 
     it("should return `NaN for `\" 123,123 \"` (since it becomes `NaN`)", () => {
         assert(isNaN(sut(" 123,123 ")));
+    });
+}
+
+function commonDouble(sut) {
+    it("should return `3.5000000000000004` for `3.5000000000000004`", () => {
+        assert.strictEqual(sut(3.5000000000000004), 3.5000000000000004);
+    });
+
+    it("should return `-3.5000000000000004` for `-3.5000000000000004`", () => {
+        assert.strictEqual(sut(-3.5000000000000004), -3.5000000000000004);
+    });
+}
+
+function commonFloat(sut) {
+    it("should return `3.5` for `3.5000000000000004`", () => {
+        assert.strictEqual(sut(3.5000000000000004), 3.5);
+    });
+
+    it("should return `-3.5` for `-3.5000000000000004`", () => {
+        assert.strictEqual(sut(-3.5000000000000004), -3.5);
+    });
+}
+
+describe("WebIDL double type", () => {
+    var sut = conversions["double"];
+
+    commonTest(sut);
+    commonRestricted(sut);
+    commonDouble(sut);
+});
+
+describe("WebIDL unrestricted double type", () => {
+    var sut = conversions["unrestricted double"];
+
+    commonTest(sut);
+    commonUnrestricted(sut);
+    commonDouble(sut);
+});
+
+describe("WebIDL float type", () => {
+    var sut = conversions["float"];
+
+    commonTest(sut);
+    commonRestricted(sut);
+    commonFloat(sut);
+
+    it("should throw a TypeError for `2 ** 128`", () => {
+        assert.throws(() => sut(Math.pow(2, 128)), TypeError);
+    });
+
+    it("should throw a TypeError for `-(2 ** 128)`", () => {
+        assert.throws(() => sut(-Math.pow(2, 128)), TypeError);
+    });
+});
+
+describe("WebIDL unrestricted float type", () => {
+    var sut = conversions["unrestricted float"];
+
+    commonTest(sut);
+    commonUnrestricted(sut);
+    commonFloat(sut);
+
+    it("should return `Infinity` for `2 ** 128`", () => {
+        assert.strictEqual(sut(Math.pow(2, 128)), Infinity);
+    });
+
+    it("should return `-Infinity` for `-(2 ** 128)`", () => {
+        assert.strictEqual(sut(-Math.pow(2, 128)), -Infinity);
     });
 });

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+describe("WebIDL object type", () => {
+    const sut = conversions["Error"];
+
+    it("should return an `Error` for an `Error`", () => {
+        const err = new Error();
+        assert.strictEqual(sut(err), err);
+    });
+
+    it("should return an `TypeError` for an `TypeError`", () => {
+        const err = new TypeError();
+        assert.strictEqual(sut(err), err);
+    });
+
+    it("should throw a TypeError for `undefined`", () => {
+        assert.throws(() => sut(undefined), TypeError);
+    });
+
+    it("should throw a TypeError for `null`", () => {
+        assert.throws(() => sut(null), TypeError);
+    });
+
+    it("should throw a TypeError for `true`", () => {
+        assert.throws(() => sut(true), TypeError);
+    });
+
+    it("should throw a TypeError for `false`", () => {
+        assert.throws(() => sut(false), TypeError);
+    });
+
+    it("should throw a TypeError for `Infinity`", () => {
+        assert.throws(() => sut(Infinity), TypeError);
+    });
+
+    it("should throw a TypeError for `NaN`", () => {
+        assert.throws(() => sut(NaN), TypeError);
+    });
+
+    it("should throw a TypeError for `0`", () => {
+        assert.throws(() => sut(0), TypeError);
+    });
+
+    it("should throw a TypeError for `''`", () => {
+        assert.throws(() => sut(""), TypeError);
+    });
+
+    it("should throw a TypeError for `Symbol.iterator`", () => {
+        assert.throws(() => sut(Symbol.iterator), TypeError);
+    });
+
+    it("should throw a TypeError for `{}`", () => {
+        assert.throws(() => sut({}), TypeError);
+    });
+
+    it("should throw a TypeError for `() => {}`", () => {
+        assert.throws(() => sut(() => {}), TypeError);
+    });
+});

--- a/test/function.js
+++ b/test/function.js
@@ -32,15 +32,21 @@ function test(type) {
             assert.strictEqual(sut(func), func);
         });
 
-        it("should return `async function () {}` for `async function () {}`", supportsAsyncFunction ? () => {
-            const func = eval("(async function () {})");
-            assert.strictEqual(sut(func), func);
-        } : undefined);
+        if (supportsAsyncFunction) {
+            it("should return `async function () {}` for `async function () {}`", () => {
+                const func = eval("(async function () {})");
+                assert.strictEqual(sut(func), func);
+            });
 
-        it("should return `async () => {}` for `async () => {}`", supportsAsyncFunction ? () => {
-            const func = eval("async () => {}");
-            assert.strictEqual(sut(func), func);
-        } : undefined);
+            it("should return `async () => {}` for `async () => {}`", () => {
+                const func = eval("async () => {}");
+                assert.strictEqual(sut(func), func);
+            });
+        } else {
+            it("should return `async function () {}` for `async function () {}`");
+
+            it("should return `async () => {}` for `async () => {}`");
+        }
 
         it("should throw a TypeError for `undefined`", () => {
             assert.throws(() => sut(undefined), TypeError);

--- a/test/function.js
+++ b/test/function.js
@@ -42,10 +42,6 @@ function test(type) {
                 const func = eval("async () => {}");
                 assert.strictEqual(sut(func), func);
             });
-        } else {
-            it("should return `async function () {}` for `async function () {}`");
-
-            it("should return `async () => {}` for `async () => {}`");
         }
 
         it("should throw a TypeError for `undefined`", () => {

--- a/test/function.js
+++ b/test/function.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+const supportsAsyncFunction = (() => {
+    try {
+        eval("(async function () {})");
+        return true;
+    } catch (err) {
+        return false;
+    }
+})();
+
+function test(type) {
+    describe("WebIDL " + type + " type", () => {
+        const sut = conversions[type];
+
+        it("should return `function () {}` for `function () {}`", () => {
+            const func = function () {};
+            assert.strictEqual(sut(func), func);
+        });
+
+        it("should return `function* () {}` for `function* () {}`", () => {
+            const func = function* () {};
+            assert.strictEqual(sut(func), func);
+        });
+
+        it("should return `() => {}` for `() => {}`", () => {
+            const func = () => {};
+            assert.strictEqual(sut(func), func);
+        });
+
+        it("should return `async function () {}` for `async function () {}`", supportsAsyncFunction ? () => {
+            const func = eval("(async function () {})");
+            assert.strictEqual(sut(func), func);
+        } : undefined);
+
+        it("should return `async () => {}` for `async () => {}`", supportsAsyncFunction ? () => {
+            const func = eval("async () => {}");
+            assert.strictEqual(sut(func), func);
+        } : undefined);
+
+        it("should throw a TypeError for `undefined`", () => {
+            assert.throws(() => sut(undefined), TypeError);
+        });
+
+        it("should throw a TypeError for `null`", () => {
+            assert.throws(() => sut(null), TypeError);
+        });
+
+        it("should throw a TypeError for `true`", () => {
+            assert.throws(() => sut(true), TypeError);
+        });
+
+        it("should throw a TypeError for `false`", () => {
+            assert.throws(() => sut(false), TypeError);
+        });
+
+        it("should throw a TypeError for `Infinity`", () => {
+            assert.throws(() => sut(Infinity), TypeError);
+        });
+
+        it("should throw a TypeError for `NaN`", () => {
+            assert.throws(() => sut(NaN), TypeError);
+        });
+
+        it("should throw a TypeError for `0`", () => {
+            assert.throws(() => sut(0), TypeError);
+        });
+
+        it("should throw a TypeError for `''`", () => {
+            assert.throws(() => sut(""), TypeError);
+        });
+
+        it("should throw a TypeError for `Symbol.iterator`", () => {
+            assert.throws(() => sut(Symbol.iterator), TypeError);
+        });
+
+        it("should throw a TypeError for `{}`", () => {
+            assert.throws(() => sut({}), TypeError);
+        });
+    });
+}
+
+test("Function");
+test("VoidFunction");

--- a/test/object.js
+++ b/test/object.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require("assert");
+
+const conversions = require("..");
+
+describe("WebIDL object type", () => {
+    const sut = conversions["object"];
+
+    it("should return `{}` for `{}`", () => {
+        const obj = {};
+        assert.strictEqual(sut(obj), obj);
+    });
+
+    it("should return `() => {}` for `() => {}`", () => {
+        const func = () => {};
+        assert.strictEqual(sut(func), func);
+    });
+
+    it("should throw a TypeError for `undefined`", () => {
+        assert.throws(() => sut(undefined), TypeError);
+    });
+
+    it("should throw a TypeError for `null`", () => {
+        assert.throws(() => sut(null), TypeError);
+    });
+
+    it("should throw a TypeError for `true`", () => {
+        assert.throws(() => sut(true), TypeError);
+    });
+
+    it("should throw a TypeError for `false`", () => {
+        assert.throws(() => sut(false), TypeError);
+    });
+
+    it("should throw a TypeError for `Infinity`", () => {
+        assert.throws(() => sut(Infinity), TypeError);
+    });
+
+    it("should throw a TypeError for `NaN`", () => {
+        assert.throws(() => sut(NaN), TypeError);
+    });
+
+    it("should throw a TypeError for `0`", () => {
+        assert.throws(() => sut(0), TypeError);
+    });
+
+    it("should throw a TypeError for `''`", () => {
+        assert.throws(() => sut(""), TypeError);
+    });
+
+    it("should throw a TypeError for `Symbol.iterator`", () => {
+        assert.throws(() => sut(Symbol.iterator), TypeError);
+    });
+});


### PR DESCRIPTION
- Fixes:
  - unrestricted double
  - float
  - unrestricted float
- Adds:
  - any
  - object
  - Error
  - Buffer source types
    - ArrayBuffer
    - DataView
    - TypedArray
  - Common definitions
    - ArrayBufferView
    - BufferSource
    - DOMTimeStamp
    - Function
    - VoidFunction
- Adds tests for all of the above
- Removes because of Web IDL spec change:
  - Date
  - RegExp