### PR TITLE
fix(`object`): Throw `TypeError` for `bigint`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -255,5 +255,15 @@
     "symbol-description": "error",
     "template-curly-spacing": ["error", "never"],
     "yield-star-spacing": ["error", "after"]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "test/**"
+      ],
+      "globals": {
+        "BigInt": "writable"
+      }
+    }
+  ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,8 @@ function type(V) {
             return "String";
         case "symbol":
             return "Symbol";
+        case "bigint":
+            return "BigInt";
         case "object":
             // Falls through
         case "function":

--- a/test/double.js
+++ b/test/double.js
@@ -9,6 +9,8 @@ function assertIs(actual, expected, message) {
     }
 }
 
+const itBigInt = typeof BigInt === "function" && typeof BigInt(0) === "bigint" ? it : it.skip;
+
 function commonTest(sut) {
     it("should return `0` for `0`", () => {
         assert.strictEqual(sut(0), 0);
@@ -48,6 +50,10 @@ function commonTest(sut) {
 
     it("should return `-123.5` for `\" -123.500 \"`", () => {
         assert.strictEqual(sut(" -123.500 "), -123.5);
+    });
+
+    itBigInt("should throw a TypeError for `0n`", () => {
+        assert.throws(() => sut(BigInt(0)), TypeError);
     });
 }
 

--- a/test/integer-types.js
+++ b/test/integer-types.js
@@ -9,6 +9,8 @@ function assertIs(actual, expected, message) {
     }
 }
 
+const itBigInt = typeof BigInt === "function" && typeof BigInt(0) === "bigint" ? it : it.skip;
+
 function commonTest(sut) {
     it("should return 0 for 0", () => {
         assertIs(sut(0), 0);
@@ -59,6 +61,10 @@ function commonTest(sut) {
 
     it("should return 123 for \" 123.400 \"", () => {
         assertIs(sut(" 123.400 "), 123);
+    });
+
+    itBigInt("should throw a TypeError for `0n`", () => {
+        assert.throws(() => sut(BigInt(0)), TypeError);
     });
 }
 

--- a/test/object.js
+++ b/test/object.js
@@ -1,8 +1,9 @@
 "use strict";
-/* global BigInt */
 const assert = require("assert");
 
 const conversions = require("..");
+
+const itBigInt = typeof BigInt === "function" && typeof BigInt(0) === "bigint" ? it : it.skip;
 
 describe("WebIDL object type", () => {
     const sut = conversions.object;
@@ -53,7 +54,6 @@ describe("WebIDL object type", () => {
         assert.throws(() => sut(Symbol.iterator), TypeError);
     });
 
-    const itBigInt = typeof BigInt === "function" && typeof BigInt(0) === "bigint" ? it : it.skip;
     itBigInt("should throw a TypeError for `0n`", () => {
         assert.throws(() => sut(BigInt(0)), TypeError);
     });

--- a/test/object.js
+++ b/test/object.js
@@ -1,4 +1,5 @@
 "use strict";
+/* global BigInt */
 const assert = require("assert");
 
 const conversions = require("..");
@@ -50,5 +51,10 @@ describe("WebIDL object type", () => {
 
     it("should throw a TypeError for `Symbol.iterator`", () => {
         assert.throws(() => sut(Symbol.iterator), TypeError);
+    });
+
+    const itBigInt = typeof BigInt === "function" && typeof BigInt(0) === "bigint" ? it : it.skip;
+    itBigInt("should throw a TypeError for `0n`", () => {
+        assert.throws(() => sut(BigInt(0)), TypeError);
     });
 });


### PR DESCRIPTION
The&nbsp;`object` type&nbsp;conversion was&nbsp;incorrectly&nbsp;treating **ES2020**&nbsp;`bigint`&nbsp;values as&nbsp;`object`&nbsp;types.

`bigint`&nbsp;values are&nbsp;supported in&nbsp;**Node.js** since&nbsp;**v10.4.0**: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility

---

review?(@domenic)