### PR TITLE
Improve buffer source type handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Conversions for all of the basic types from the Web IDL specification are implem
 - [`DOMString`](https://heycam.github.io/webidl/#es-DOMString), which can additionally be provided the boolean option `{ treatNullAsEmptyString }` as a second parameter
 - [`ByteString`](https://heycam.github.io/webidl/#es-ByteString), [`USVString`](https://heycam.github.io/webidl/#es-USVString)
 - [`object`](https://heycam.github.io/webidl/#es-object)
-- [Buffer source types](https://heycam.github.io/webidl/#es-buffer-source-types)
+- [Buffer source types](https://heycam.github.io/webidl/#es-buffer-source-types), which can additionally be provided with the boolean option `{ allowShared }` as a second parameter
 
 Additionally, for convenience, the following derived type definitions are implemented:
 
-- [`ArrayBufferView`](https://heycam.github.io/webidl/#ArrayBufferView)
+- [`ArrayBufferView`](https://heycam.github.io/webidl/#ArrayBufferView), which can additionally be provided with the boolean option `{ allowShared }` as a second parameter
 - [`BufferSource`](https://heycam.github.io/webidl/#BufferSource)
 - [`DOMTimeStamp`](https://heycam.github.io/webidl/#DOMTimeStamp)
 - [`Function`](https://heycam.github.io/webidl/#Function)
@@ -75,6 +75,10 @@ The `long long` and `unsigned long long` Web IDL types can hold values that cann
 To mitigate this, we could return the raw BigInt value from the conversion function, but right now it is not implemented. If your use case requires such precision, [file an issue](https://github.com/jsdom/webidl-conversions/issues/new).
 
 On the other hand, `long long` conversion is always accurate, since the input value can never be more precise than the output value.
+
+### A note on `BufferSource` types
+
+All of the `BufferSource` types will throw when the relevant `ArrayBuffer` has been detached. This technically is not part of the [specified conversion algorithm](https://heycam.github.io/webidl/#es-buffer-source-types), but instead part of the [getting a reference/getting a copy](https://heycam.github.io/webidl/#ref-for-dfn-get-buffer-source-reference%E2%91%A0) algorithms. We've consolidated them here for convenience and ease of implementation, but if there is a need to separate them in the future, please open an issue so we can investigate.
 
 ## Background
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,11 +107,7 @@ function createIntegerConversion(bitLength, typeOpts) {
     const twoToTheBitLength = Math.pow(2, bitLength);
     const twoToOneLessThanTheBitLength = Math.pow(2, bitLength - 1);
 
-    return (V, opts) => {
-        if (opts === undefined) {
-            opts = {};
-        }
-
+    return (V, opts = {}) => {
         let x = toNumber(V, opts);
         x = censorNegativeZero(x);
 
@@ -274,11 +270,7 @@ exports["unrestricted float"] = (V, opts) => {
     return Math.fround(x);
 };
 
-exports.DOMString = function (V, opts) {
-    if (opts === undefined) {
-        opts = {};
-    }
-
+exports.DOMString = function (V, opts = {}) {
     if (opts.treatNullAsEmptyString && V === null) {
         return "";
     }
@@ -352,33 +344,71 @@ function convertCallbackFunction(V, opts) {
 
 const abByteLengthGetter =
     Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength").get;
+const sabByteLengthGetter =
+    Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "byteLength").get;
 
-function isArrayBuffer(V) {
+function isNonSharedArrayBuffer(V) {
     try {
+        // This will throw on SharedArrayBuffers, but not detached ArrayBuffers.
+        // (The spec says it should throw, but the spec conflicts with implementations: https://github.com/tc39/ecma262/issues/678)
         abByteLengthGetter.call(V);
+
         return true;
-    } catch (e) {
+    } catch {
         return false;
     }
 }
 
-// I don't think we can reliably detect detached ArrayBuffers.
-exports.ArrayBuffer = (V, opts) => {
-    if (!isArrayBuffer(V)) {
-        throw makeException(TypeError, "is not a view on an ArrayBuffer object", opts);
+function isSharedArrayBuffer(V) {
+    try {
+        sabByteLengthGetter.call(V);
+        return true;
+    } catch {
+        return false;
     }
+}
+
+function isArrayBufferDetached(V) {
+    try {
+        // eslint-disable-next-line no-new
+        new Uint8Array(V);
+        return false;
+    } catch {
+        return true;
+    }
+}
+
+exports.ArrayBuffer = (V, opts = {}) => {
+    if (!isNonSharedArrayBuffer(V)) {
+        if (opts.allowShared && !isSharedArrayBuffer(V)) {
+            throw makeException(TypeError, "is not an ArrayBuffer or SharedArrayBuffer", opts);
+        }
+        throw makeException(TypeError, "is not an ArrayBuffer", opts);
+    }
+    if (isArrayBufferDetached(V)) {
+        throw makeException(TypeError, "is a detached ArrayBuffer", opts);
+    }
+
     return V;
 };
 
 const dvByteLengthGetter =
     Object.getOwnPropertyDescriptor(DataView.prototype, "byteLength").get;
-exports.DataView = (V, opts) => {
+exports.DataView = (V, opts = {}) => {
     try {
         dvByteLengthGetter.call(V);
-        return V;
     } catch (e) {
-        throw makeException(TypeError, "is not a view on an DataView object", opts);
+        throw makeException(TypeError, "is not a DataView", opts);
     }
+
+    if (!opts.allowShared && isSharedArrayBuffer(V.buffer)) {
+        throw makeException(TypeError, "is backed by a SharedArrayBuffer, which is not allowed", opts);
+    }
+    if (isArrayBufferDetached(V.buffer)) {
+        throw makeException(TypeError, "is backed by a detached ArrayBuffer", opts);
+    }
+
+    return V;
 };
 
 // Returns the unforgeable `TypedArray` constructor name or `undefined`,
@@ -395,9 +425,15 @@ const typedArrayNameGetter = Object.getOwnPropertyDescriptor(
 ].forEach(func => {
     const name = func.name;
     const article = /^[AEIOU]/.test(name) ? "an" : "a";
-    exports[name] = (V, opts) => {
+    exports[name] = (V, opts = {}) => {
         if (!ArrayBuffer.isView(V) || typedArrayNameGetter.call(V) !== name) {
             throw makeException(TypeError, `is not ${article} ${name} object`, opts);
+        }
+        if (!opts.allowShared && isSharedArrayBuffer(V.buffer)) {
+            throw makeException(TypeError, "is a view on a SharedArrayBuffer, which is not allowed", opts);
+        }
+        if (isArrayBufferDetached(V.buffer)) {
+            throw makeException(TypeError, "is a view on a detached ArrayBuffer", opts);
         }
 
         return V;
@@ -406,17 +442,41 @@ const typedArrayNameGetter = Object.getOwnPropertyDescriptor(
 
 // Common definitions
 
-exports.ArrayBufferView = (V, opts) => {
+exports.ArrayBufferView = (V, opts = {}) => {
     if (!ArrayBuffer.isView(V)) {
-        throw makeException(TypeError, "is not a view on an ArrayBuffer object", opts);
+        throw makeException(TypeError, "is not a view on an ArrayBuffer or SharedArrayBuffer", opts);
     }
 
+    if (!opts.allowShared && isSharedArrayBuffer(V.buffer)) {
+        throw makeException(TypeError, "is a view on a SharedArrayBuffer, which is not allowed", opts);
+    }
+
+    if (isArrayBufferDetached(V.buffer)) {
+        throw makeException(TypeError, "is a view on a detached ArrayBuffer", opts);
+    }
     return V;
 };
 
-exports.BufferSource = (V, opts) => {
-    if (!ArrayBuffer.isView(V) && !isArrayBuffer(V)) {
-        throw makeException(TypeError, "is not an ArrayBuffer object or a view on one", opts);
+exports.BufferSource = (V, opts = {}) => {
+    if (ArrayBuffer.isView(V)) {
+        if (!opts.allowShared && isSharedArrayBuffer(V.buffer)) {
+            throw makeException(TypeError, "is a view on a SharedArrayBuffer, which is not allowed", opts);
+        }
+
+        if (isArrayBufferDetached(V.buffer)) {
+            throw makeException(TypeError, "is a view on a detached ArrayBuffer", opts);
+        }
+        return V;
+    }
+
+    if (!opts.allowShared && !isNonSharedArrayBuffer(V)) {
+        throw makeException(TypeError, "is not an ArrayBuffer or a view on one", opts);
+    }
+    if (opts.allowShared && !isSharedArrayBuffer(V) && !isNonSharedArrayBuffer(V)) {
+        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBufer, or a view on one", opts);
+    }
+    if (isArrayBufferDetached(V)) {
+        throw makeException(TypeError, "is a detached ArrayBuffer", opts);
     }
 
     return V;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha test/*.js",
+    "test": "node --experimental-worker node_modules/mocha/bin/_mocha test/*.js",
     "coverage": "nyc mocha test/*.js"
   },
   "repository": "jsdom/webidl-conversions",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "node --experimental-worker node_modules/mocha/bin/_mocha test/*.js",
+    "test": "node node_modules/mocha/bin/_mocha test/*.js",
     "coverage": "nyc mocha test/*.js"
   },
   "repository": "jsdom/webidl-conversions",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "node node_modules/mocha/bin/_mocha test/*.js",
+    "test": "mocha test/*.js",
     "coverage": "nyc mocha test/*.js"
   },
   "repository": "jsdom/webidl-conversions",

--- a/test/buffer-source.js
+++ b/test/buffer-source.js
@@ -62,14 +62,14 @@ function commonNotOk(sut) {
 }
 
 function testOk(name, sut, create) {
-    it("should return input for `" + name + "` object", () => {
+    it(`should return input for ${name}`, () => {
         const obj = create();
         assert.strictEqual(sut(obj), obj);
     });
 }
 
 function testNotOk(name, sut, create) {
-    it("should throw a TypeError for `" + name + "` object", () => {
+    it(`should throw a TypeError for ${name}`, () => {
         assertThrows(sut, [create()], TypeError);
     });
 }
@@ -112,7 +112,7 @@ if (MessageChannel) {
         typeName: "ArrayBuffer",
         isShared: false,
         isDetached: true,
-        label: "ArrayBuffer detached",
+        label: "detached ArrayBuffer",
         creator: () => {
             const value = new ArrayBuffer(0);
             const { port1 } = new MessageChannel();
@@ -177,7 +177,7 @@ for (const constructor of bufferSourceConstructors) {
             isShared: false,
             isDetached: true,
             isForged: false,
-            label: `${name} detached`,
+            label: `detached ${name}`,
             creator: () => {
                 const value = new constructor(new ArrayBuffer(0));
                 const { port1 } = new MessageChannel();


### PR DESCRIPTION
* Properly prohibit SharedArrayBuffers by default
* Introduce the allowShared option to allow them
* Throw on detached ArrayBuffers

This also starts using syntax features and the worker_threads module supported only in Node v10. This is done only in the tests, but since it's inconvenient to run the tests on Node v8, we raise the minimum version to v10.