### PR TITLE
chore: Fix `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,5 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[.eslintrc.json]
-[package.json]
-[.travis.yml]
+[{.eslintrc.json,package.json,.travis.yml}]
 indent_size = 2


### PR DESCRIPTION
Without&nbsp;this, the&nbsp;`indent_size` for&nbsp;`package.json` and&nbsp;`.eslintrc.json` was&nbsp;incorrectly&nbsp;inferred&nbsp;as&nbsp;`4`.