### PR TITLE
fix: Make `TypedArray` conversion unforgeable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -337,6 +337,14 @@ exports.DataView = (V, opts) => {
     }
 };
 
+// Returns the unforgeable `TypedArray` constructor name or `undefined`,
+// if the `this` value isn't a valid `TypedArray` object.
+//
+// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
+const typedArrayNameGetter = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(Uint8Array).prototype,
+    Symbol.toStringTag
+).get;
 [
     Int8Array, Int16Array, Int32Array, Uint8Array,
     Uint16Array, Uint32Array, Uint8ClampedArray, Float32Array, Float64Array
@@ -344,7 +352,7 @@ exports.DataView = (V, opts) => {
     const name = func.name;
     const article = /^[AEIOU]/.test(name) ? "an" : "a";
     exports[name] = (V, opts) => {
-        if (!ArrayBuffer.isView(V) || V.constructor.name !== name) {
+        if (!ArrayBuffer.isView(V) || typedArrayNameGetter.call(V) !== name) {
             throw makeException(TypeError, `is not ${article} ${name} object`, opts);
         }
 


### PR DESCRIPTION
This&nbsp;makes&nbsp;use of&nbsp;the&nbsp;fact&nbsp;that the&nbsp;[<code>%TypedArray%.prototype&nbsp;[&nbsp;\@\@toStringTag&nbsp;]</code>](https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag)&nbsp;property is&nbsp;a&nbsp;getter&nbsp;function that&nbsp;returns&nbsp;the&nbsp;value of&nbsp;the&nbsp;<code><var>this</var>.[[TypedArrayName]]</code> internal&nbsp;slot, [which&nbsp;contains the&nbsp;unforgeable <code><var>TypedArray</var></code> constructor&nbsp;name](https://tc39.es/ecma262/#table-the-typedarray-constructors).

This&nbsp;is&nbsp;also how&nbsp;the&nbsp;<code>util.types.is<var>TypedArray</var></code>&nbsp;functions [are&nbsp;implemented&nbsp;in&nbsp;**Node**](https://github.com/nodejs/node/blob/7e911d8b03a838e5ac6bb06c5b313533e89673ef/lib/internal/util/types.js#L11-L64).

---

See&nbsp;also: https://github.com/jsdom/webidl-conversions/issues/12