### PR TITLE
fix(type): Use correct object detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,46 +4,6 @@ function _(message, opts) {
     return `${opts && opts.context ? opts.context : "Value"} ${message}.`;
 }
 
-const objValueOf = Object.prototype.valueOf;
-function type(V) {
-    if (V === null) {
-        return "Null";
-    }
-    if (V === undefined) {
-        return "Undefined";
-    }
-    switch (typeof V) {
-        case "boolean":
-            return "Boolean";
-        case "number":
-            return "Number";
-        case "string":
-            return "String";
-        case "symbol":
-            return "Symbol";
-        case "bigint":
-            return "BigInt";
-        case "object":
-            // Falls through
-        case "function":
-            // Falls through
-        default:
-            // Per ES spec, typeof returns an implemention-defined value that is not any of the existing ones for
-            // uncallable non-standard exotic objects. Yet Type() which the Web IDL spec depends on returns Object for
-            // such cases. So treat the default case as an object.
-
-            // This will also be hit for objects with the `[[IsHTMLDDA]]` internal slot,
-            // which causes typeof to return "undefined".
-            try {
-                // %ObjProto_valueOf% acts an identity function for real objects
-                if (objValueOf.call(V) === V) {
-                    return "Object";
-                }
-            } catch (err) { /* Ignore */ }
-            return "Unknown";
-    }
-}
-
 // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
 function evenRound(x) {
     // There are four cases for numbers with fractional part being .5:
@@ -284,8 +244,41 @@ exports.USVString = (V, opts) => {
     return U.join("");
 };
 
+const objProtoValueOf = Object.prototype.valueOf;
+function isObject(V) {
+    if (V === null || V === undefined) {
+        return false;
+    }
+
+    switch (typeof V) {
+        // Short-circuit for known primitive types:
+        case "boolean":
+        case "number":
+        case "string":
+        case "symbol":
+        case "bigint":
+            return false;
+
+        // This will match "object", "function", and any of old IE's non-standard typeof extensions.
+        default:
+            // Per ES spec, typeof returns an implemention-defined value that is not any of the existing ones for
+            // uncallable non-standard exotic objects. Yet Type() which the Web IDL spec depends on returns Object for
+            // such cases. So treat the default case as an object.
+
+            // This will also be hit for objects with the `[[IsHTMLDDA]]` internal slot,
+            // which causes typeof to return "undefined".
+            try {
+                // %ObjProto_valueOf% acts an identity function for real objects,
+                // but will box primitive values.
+                return objProtoValueOf.call(V) === V;
+            } catch (err) { /* Ignore */ }
+    }
+
+    return false;
+}
+
 exports.object = (V, opts) => {
-    if (type(V) !== "Object") {
+    if (!isObject(V)) {
         throw new TypeError(_("is not an object", opts));
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,15 @@ function _(message, opts) {
     return `${opts && opts.context ? opts.context : "Value"} ${message}.`;
 }
 
+const objValueOf = Object.prototype.valueOf;
 function type(V) {
     if (V === null) {
         return "Null";
     }
+    if (V === undefined) {
+        return "Undefined";
+    }
     switch (typeof V) {
-        case "undefined":
-            return "Undefined";
         case "boolean":
             return "Boolean";
         case "number":
@@ -29,7 +31,16 @@ function type(V) {
             // Per ES spec, typeof returns an implemention-defined value that is not any of the existing ones for
             // uncallable non-standard exotic objects. Yet Type() which the Web IDL spec depends on returns Object for
             // such cases. So treat the default case as an object.
-            return "Object";
+
+            // This will also be hit for objects with the `[[IsHTMLDDA]]` internal slot,
+            // which causes typeof to return "undefined".
+            try {
+                // %ObjProto_valueOf% acts an identity function for real objects
+                if (objValueOf.call(V) === V) {
+                    return "Object";
+                }
+            } catch (err) { /* Ignore */ }
+            return "Unknown";
     }
 }
 
@@ -282,14 +293,17 @@ exports.object = (V, opts) => {
 };
 
 // Not exported, but used in Function and VoidFunction.
+const funcToString = Function.prototype.toString;
 
 // Neither Function nor VoidFunction is defined with [TreatNonObjectAsNull], so
 // handling for that is omitted.
 function convertCallbackFunction(V, opts) {
-    if (typeof V !== "function") {
+    try {
+        funcToString.call(V);
+        return V;
+    } catch (err) {
         throw new TypeError(_("is not a function", opts));
     }
-    return V;
 }
 
 const abByteLengthGetter =

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha test/*.js",
-    "coverage": "nyc mocha test/*.js"
+    "test": "mocha --v8-allow-natives-syntax test/*.js",
+    "coverage": "nyc mocha --v8-allow-natives-syntax test/*.js"
   },
   "repository": "jsdom/webidl-conversions",
   "keywords": [

--- a/test/function.js
+++ b/test/function.js
@@ -14,6 +14,17 @@ const supportsAsyncFunction = (() => {
     }
 })();
 
+const documentAll = (() => {
+    try {
+        // eslint-disable-next-line no-eval
+        const docAll = (0, eval)("%GetUndetectable()");
+        Function.prototype.toString.call(docAll);
+        return docAll;
+    } catch (err) {
+        return false;
+    }
+})();
+
 function test(type) {
     describe("WebIDL " + type + " type", () => {
         const sut = conversions[type];
@@ -44,6 +55,11 @@ function test(type) {
                 assert.strictEqual(sut(func), func);
             });
         }
+
+        const itHTMLDDA = documentAll !== false ? it : it.skip;
+        itHTMLDDA("should return `document.all` for `document.all` (needs --allow-natives-syntax)", () => {
+            assert.strictEqual(sut(documentAll), documentAll);
+        });
 
         it("should throw a TypeError for `undefined`", () => {
             assert.throws(() => sut(undefined), TypeError);

--- a/test/object.js
+++ b/test/object.js
@@ -18,6 +18,22 @@ describe("WebIDL object type", () => {
         assert.strictEqual(sut(func), func);
     });
 
+    {
+        const documentAll = (() => {
+            try {
+                // eslint-disable-next-line no-eval
+                return (0, eval)("%GetUndetectable()");
+            } catch (err) {
+                return false;
+            }
+        })();
+
+        const itHTMLDDA = documentAll !== false ? it : it.skip;
+        itHTMLDDA("should return `document.all` for `document.all` (needs --allow-natives-syntax)", () => {
+            assert.strictEqual(sut(documentAll), documentAll);
+        });
+    }
+
     it("should throw a TypeError for `undefined`", () => {
         assert.throws(() => sut(undefined), TypeError);
     });


### PR DESCRIPTION
This makes the `type` helper only return `Object` for actual objects, ensuring that in case **ECMAScript** ever adds another primitive value, #19 won’t be required again.

It also has the added benefit of treating objects with [the `[[IsHTMLDDA]]` internal slot](https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot) as objects, like actual **WebIDL**.

This is tested by using **V8**’s `%GetUndetecteable()` helper, which creates a function with the `[[IsHTMLDDA]]` internal slot.