### PR TITLE
Use `is‑true‑object` to detect objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const isObject = require("is-true-object");
+
 function makeException(ErrorType, message, opts = {}) {
     if (opts.globals) {
         ErrorType = opts.globals[ErrorType.name];
@@ -15,35 +17,6 @@ function toNumber(value, opts = {}) {
         throw opts.globals.TypeError("Cannot convert a BigInt value to a number");
     }
     return opts.globals.Number(value);
-}
-
-function type(V) {
-    if (V === null) {
-        return "Null";
-    }
-    switch (typeof V) {
-        case "undefined":
-            return "Undefined";
-        case "boolean":
-            return "Boolean";
-        case "number":
-            return "Number";
-        case "string":
-            return "String";
-        case "symbol":
-            return "Symbol";
-        case "bigint":
-            return "BigInt";
-        case "object":
-            // Falls through
-        case "function":
-            // Falls through
-        default:
-            // Per ES spec, typeof returns an implemention-defined value that is not any of the existing ones for
-            // uncallable non-standard exotic objects. Yet Type() which the Web IDL spec depends on returns Object for
-            // such cases. So treat the default case as an object.
-            return "Object";
-    }
 }
 
 // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
@@ -332,7 +305,7 @@ exports.USVString = (V, opts) => {
 };
 
 exports.object = (V, opts) => {
-    if (type(V) !== "Object") {
+    if (!isObject(V)) {
         throw makeException(TypeError, "is not an object", opts);
     }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "BSD-2-Clause",
+  "dependencies": {
+    "is-true-object": "^1.0.0"
+  },
   "devDependencies": {
     "eslint": "^6.8.0",
     "mocha": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,6 +1045,11 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
+is-true-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-true-object/-/is-true-object-1.0.0.tgz#f1fa42d6e5e72ff817c93a698683ed76d84d1f33"
+  integrity sha512-7rmzO0agY32z34Mq48pEMZRyXv1hnd+8AJyZcjQQ+Pv/DCVd3h/lpkVRTDd/nbMJAz1WnNvbbGssNdbNsZEyGw==
+
 is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"


### PR DESCRIPTION
`is‑true‑object` is [a tiny package][bundlephobia]¹ that implements a forward‑compatible and spec‑accurate implementation of `Type(V) is Object`, which also supports legacy pre‑**ES2020** exotic `typeof` values.

This will also have the added bonus of being usable by **WebIDL2JS**’s `utils.js`, which currently doesn’t support legacy exotic `typeof` values.

---

¹ **0.5kb** minified and **0.25kb** minified + gzipped

[bundlephobia]: https://bundlephobia.com/result?p=is-true-object@1