### PR TITLE
Editorial: Fix typos and dead code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,10 +158,6 @@ function createLongLongConversion(bitLength, { unsigned }) {
     const asBigIntN = unsigned ? BigInt.asUintN : BigInt.asIntN;
 
     return (V, opts = {}) => {
-        if (opts === undefined) {
-            opts = {};
-        }
-
         let x = toNumber(V, opts);
         x = censorNegativeZero(x);
 
@@ -473,7 +469,7 @@ exports.BufferSource = (V, opts = {}) => {
         throw makeException(TypeError, "is not an ArrayBuffer or a view on one", opts);
     }
     if (opts.allowShared && !isSharedArrayBuffer(V) && !isNonSharedArrayBuffer(V)) {
-        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBufer, or a view on one", opts);
+        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBuffer, or a view on one", opts);
     }
     if (isArrayBufferDetached(V)) {
         throw makeException(TypeError, "is a detached ArrayBuffer", opts);


### PR DESCRIPTION
The dead code snuck in as a result of <https://github.com/jsdom/webidl-conversions/pull/20> and <https://github.com/jsdom/webidl-conversions/pull/26> being developed in parallel.