### PR TITLE
fixed catch blocks missing identifiers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,6 +158,10 @@ function createLongLongConversion(bitLength, { unsigned }) {
     const asBigIntN = unsigned ? BigInt.asUintN : BigInt.asIntN;
 
     return (V, opts = {}) => {
+        if (opts === undefined) {
+            opts = {};
+        }
+
         let x = toNumber(V, opts);
         x = censorNegativeZero(x);
 
@@ -350,7 +354,7 @@ function isNonSharedArrayBuffer(V) {
         abByteLengthGetter.call(V);
 
         return true;
-    } catch {
+    } catch (e) {
         return false;
     }
 }
@@ -359,7 +363,7 @@ function isSharedArrayBuffer(V) {
     try {
         sabByteLengthGetter.call(V);
         return true;
-    } catch {
+    } catch (e) {
         return false;
     }
 }
@@ -369,7 +373,7 @@ function isArrayBufferDetached(V) {
         // eslint-disable-next-line no-new
         new Uint8Array(V);
         return false;
-    } catch {
+    } catch (e) {
         return true;
     }
 }
@@ -469,7 +473,7 @@ exports.BufferSource = (V, opts = {}) => {
         throw makeException(TypeError, "is not an ArrayBuffer or a view on one", opts);
     }
     if (opts.allowShared && !isSharedArrayBuffer(V) && !isNonSharedArrayBuffer(V)) {
-        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBuffer, or a view on one", opts);
+        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBufer, or a view on one", opts);
     }
     if (isArrayBufferDetached(V)) {
         throw makeException(TypeError, "is a detached ArrayBuffer", opts);

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,10 +158,6 @@ function createLongLongConversion(bitLength, { unsigned }) {
     const asBigIntN = unsigned ? BigInt.asUintN : BigInt.asIntN;
 
     return (V, opts = {}) => {
-        if (opts === undefined) {
-            opts = {};
-        }
-
         let x = toNumber(V, opts);
         x = censorNegativeZero(x);
 
@@ -473,7 +469,7 @@ exports.BufferSource = (V, opts = {}) => {
         throw makeException(TypeError, "is not an ArrayBuffer or a view on one", opts);
     }
     if (opts.allowShared && !isSharedArrayBuffer(V) && !isNonSharedArrayBuffer(V)) {
-        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBufer, or a view on one", opts);
+        throw makeException(TypeError, "is not an ArrayBuffer, SharedArrayBuffer, or a view on one", opts);
     }
     if (isArrayBufferDetached(V)) {
         throw makeException(TypeError, "is a detached ArrayBuffer", opts);


### PR DESCRIPTION
to comply with es5 javascript standard
as commented about on issue 2963 here:
https://github.com/jsdom/jsdom/issues/2963