### PR TITLE
Fix toNumber BigInt exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ function makeException(ErrorType, message, opts = {}) {
 
 function toNumber(value, opts = {}) {
   if (typeof value === "bigint") {
-    throw opts.globals.TypeError("Cannot convert a BigInt value to a number");
+    throw makeException(TypeError, "is a BigInt which cannot be converted to a number", opts);
   }
   if (!opts.globals) {
     return Number(value);


### PR DESCRIPTION
This bug was introduced in 4f444d8a23dff8a4e04165a2cf0e81dc7eae1678 when I tried to fix a lint error by moving an exception-throwing line higher. However, by doing so I made toNumber() only work when the globals option is provided.

By moving to makeException, we fix the bug and get better error messages.

This is hard to test since triggering the bug would throw a same-realm TypeError anyway, which is the desired state. We would have to start testing exception text, which would require new infrastructure.