### PR TITLE
Add conversion for `SharedArrayBuffer`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -338,13 +338,7 @@ function isArrayBufferDetached(value) {
 
 exports.ArrayBuffer = (value, options = {}) => {
   if (!isNonSharedArrayBuffer(value)) {
-    if (options.allowShared) {
-      if (!isSharedArrayBuffer(value)) {
-        throw makeException(TypeError, "is not an ArrayBuffer or SharedArrayBuffer", options);
-      }
-    } else {
-      throw makeException(TypeError, "is not an ArrayBuffer", options);
-    }
+    throw makeException(TypeError, "is not an ArrayBuffer", options);
   }
   if (isArrayBufferDetached(value)) {
     throw makeException(TypeError, "is a detached ArrayBuffer", options);

--- a/test/buffer-source.js
+++ b/test/buffer-source.js
@@ -211,11 +211,7 @@ for (const type of bufferSourceConstructors) {
       const allowSharedSUT = (v, opts) => conversions[typeName](v, { ...opts, allowShared: true });
 
       for (const { label, creator, typeName: innerTypeName, isDetached, isForged } of bufferSourceCreators) {
-        const testFunction = (
-            innerTypeName === typeName || (innerTypeName === "SharedArrayBuffer" && typeName === "ArrayBuffer")
-          ) && !isDetached && !isForged ?
-            testOk :
-            testNotOk;
+        const testFunction = innerTypeName === typeName && !isDetached && !isForged ? testOk : testNotOk;
         testFunction(label, allowSharedSUT, creator);
       }
 


### PR DESCRIPTION
As of https://github.com/whatwg/webidl/pull/1311, WebIDL has its own `SharedArrayBuffer` type. I added a `conversions.SharedArrayBuffer` function to properly recognize this.

I also noticed that this conversion was incorrectly throwing an error, so [I fixed that](https://github.com/MattiasBuelens/webidl-conversions/commit/8a3e8cb2e5618786ee4ff1581d0afacd20db1f22):
```javascript
const converted = conversions.ArrayBuffer(new SharedArrayBuffer(0), { allowShared: true });
```

Questions:
* The old way of denoting this was `[AllowShared] ArrayBuffer`. However, that's no longer supported: [you can only apply `[AllowShared]` on a buffer view type](https://webidl.spec.whatwg.org/#AllowShared). For now, I've kept the `allowShared` option around in `conversions.ArrayBuffer`, but perhaps we should remove it instead?