### PR TITLE
Add `allowResizable` to (Shared)ArrayBuffer conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Conversions for all of the basic types from the Web IDL specification are implem
 - [`DOMString`](https://heycam.github.io/webidl/#es-DOMString), which can additionally be provided the boolean option `{ treatNullAsEmptyString }` as a second parameter
 - [`ByteString`](https://heycam.github.io/webidl/#es-ByteString), [`USVString`](https://heycam.github.io/webidl/#es-USVString)
 - [`object`](https://heycam.github.io/webidl/#es-object)
-- [Buffer source types](https://heycam.github.io/webidl/#es-buffer-source-types), which can additionally be provided with the boolean option `{ allowShared }` as a second parameter
+- [Buffer source types](https://heycam.github.io/webidl/#es-buffer-source-types), which can additionally be provided with the boolean option bag `{ allowShared, allowResizable }` as a second parameter
 
 Additionally, for convenience, the following derived type definitions are implemented:
 
-- [`ArrayBufferView`](https://heycam.github.io/webidl/#ArrayBufferView), which can additionally be provided with the boolean option `{ allowShared }` as a second parameter
+- [`ArrayBufferView`](https://heycam.github.io/webidl/#ArrayBufferView), which can additionally be provided with the boolean option bag `{ allowShared, allowResizable }` as a second parameter
 - [`BufferSource`](https://heycam.github.io/webidl/#BufferSource)
 - [`DOMTimeStamp`](https://heycam.github.io/webidl/#DOMTimeStamp)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -372,9 +372,6 @@ exports.SharedArrayBuffer = (value, options = {}) => {
   if (!options.allowResizable && isSharedArrayBufferGrowable(value)) {
     throw makeException(TypeError, "is a growable SharedArrayBuffer", options);
   }
-  if (isArrayBufferDetached(value)) {
-    throw makeException(TypeError, "is a detached SharedArrayBuffer", options);
-  }
 
   return value;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -322,6 +322,25 @@ function isSharedArrayBuffer(value) {
   }
 }
 
+const abResizableGetter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable").get;
+const sabGrowableGetter = Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "growable").get;
+
+function isNonSharedArrayBufferResizable(value) {
+  try {
+    return abResizableGetter.call(value);
+  } catch {
+    return false;
+  }
+}
+
+function isSharedArrayBufferGrowable(value) {
+  try {
+    return sabGrowableGetter.call(value);
+  } catch {
+    return false;
+  }
+}
+
 function isArrayBufferDetached(value) {
   try {
     // eslint-disable-next-line no-new
@@ -336,6 +355,9 @@ exports.ArrayBuffer = (value, options = {}) => {
   if (!isNonSharedArrayBuffer(value)) {
     throw makeException(TypeError, "is not an ArrayBuffer", options);
   }
+  if (!options.allowResizable && isNonSharedArrayBufferResizable(value)) {
+    throw makeException(TypeError, "is a resizable ArrayBuffer", options);
+  }
   if (isArrayBufferDetached(value)) {
     throw makeException(TypeError, "is a detached ArrayBuffer", options);
   }
@@ -346,6 +368,9 @@ exports.ArrayBuffer = (value, options = {}) => {
 exports.SharedArrayBuffer = (value, options = {}) => {
   if (!isSharedArrayBuffer(value)) {
     throw makeException(TypeError, "is not a SharedArrayBuffer", options);
+  }
+  if (!options.allowResizable && isSharedArrayBufferGrowable(value)) {
+    throw makeException(TypeError, "is a growable SharedArrayBuffer", options);
   }
   if (isArrayBufferDetached(value)) {
     throw makeException(TypeError, "is a detached SharedArrayBuffer", options);
@@ -403,6 +428,14 @@ exports.ArrayBufferView = (value, options = {}) => {
 
   if (!options.allowShared && isSharedArrayBuffer(value.buffer)) {
     throw makeException(TypeError, "is a view on a SharedArrayBuffer, which is not allowed", options);
+  }
+
+  if (!options.allowResizable) {
+    if (isNonSharedArrayBufferResizable(value.buffer)) {
+      throw makeException(TypeError, "is a view on a resizable ArrayBuffer, which is not allowed", options);
+    } else if (isSharedArrayBufferGrowable(value.buffer)) {
+      throw makeException(TypeError, "is a view on a growable SharedArrayBuffer, which is not allowed", options);
+    }
   }
 
   if (isArrayBufferDetached(value.buffer)) {

--- a/test/buffer-source.js
+++ b/test/buffer-source.js
@@ -312,6 +312,23 @@ for (const type of bufferSourceConstructors) {
 
       commonNotOk(allowResizableSUT);
     });
+
+    describe("with [AllowShared, AllowResizable]", () => {
+      const allowSharedAndResizableSUT = (v, opts) => {
+        return conversions[typeName](v, { ...opts, allowShared: true, allowResizable: true });
+      };
+
+      for (const { label, creator, typeName: innerTypeName, isDetached, isForged } of bufferSourceCreators) {
+        const testFunction = innerTypeName === typeName &&
+        !isDetached &&
+        !isForged ?
+          testOk :
+          testNotOk;
+        testFunction(label, allowSharedAndResizableSUT, creator);
+      }
+
+      commonNotOk(allowSharedAndResizableSUT);
+    });
   });
 }
 
@@ -405,6 +422,26 @@ describe("WebIDL ArrayBufferView type", () => {
 
     commonNotOk(allowResizableSUT);
   });
+
+  describe("with [AllowShared, AllowResizable]", () => {
+    const allowResizableSUT = (v, opts) => {
+      return conversions.ArrayBufferView(v, { ...opts, allowShared: true, allowResizable: true });
+    };
+
+    for (const { label, creator, typeName, isDetached, isForged } of bufferSourceCreators) {
+      const testFunction =
+        typeName !== "ArrayBuffer" &&
+        typeName !== "SharedArrayBuffer" &&
+        !isDetached &&
+        !isForged ?
+          testOk :
+          testNotOk;
+
+      testFunction(label, allowResizableSUT, creator);
+    }
+
+    commonNotOk(allowResizableSUT);
+  });
 });
 
 describe("WebIDL BufferSource type", () => {
@@ -433,6 +470,19 @@ describe("WebIDL BufferSource type", () => {
 
     for (const { label, creator, isShared, isDetached, isForged } of bufferSourceCreators) {
       const testFunction = !isShared && !isDetached && !isForged ? testOk : testNotOk;
+      testFunction(label, allowResizableSUT, creator);
+    }
+
+    commonNotOk(allowResizableSUT);
+  });
+
+  describe("with [AllowShared, AllowResizable]", () => {
+    const allowResizableSUT = (v, opts) => {
+      return conversions.BufferSource(v, { ...opts, allowShared: true, allowResizable: true });
+    };
+
+    for (const { label, creator, isDetached, isForged } of bufferSourceCreators) {
+      const testFunction = !isDetached && !isForged ? testOk : testNotOk;
       testFunction(label, allowResizableSUT, creator);
     }
 


### PR DESCRIPTION
This implements the [`[AllowResizable]` attribute](https://webidl.spec.whatwg.org/#AllowResizable) introduced in https://github.com/whatwg/webidl/pull/982.